### PR TITLE
Runtime factories by string key

### DIFF
--- a/packages/auto_localized/lib/auto_localized.dart
+++ b/packages/auto_localized/lib/auto_localized.dart
@@ -1,5 +1,6 @@
 library auto_localized;
 
+export 'package:auto_localized/src/exception/localized_not_found.dart';
 export 'package:auto_localized/src/localization/auto_localization.dart';
 export 'package:auto_localized/src/localization/auto_localization_delegate.dart';
 export 'package:auto_localized/src/string/arg_localized_string_1.dart';

--- a/packages/auto_localized/lib/src/annotation/auto_localized.dart
+++ b/packages/auto_localized/lib/src/annotation/auto_localized.dart
@@ -71,10 +71,25 @@ class AutoLocalized {
   ///
   final bool generateGetterMethods;
 
+  /// When set to true you will gain access to additional methods `ofKey` and
+  /// `maybeOfKey`. They will allow you to get [LocalizedString] at runtime
+  /// with key from translation file, for example:
+  /// ```dart
+  /// Strings.ofKey('test_message').getRaw();
+  ///
+  /// // or with cast
+  /// (Strings.ofKey('test_message') as ArgLocalizedString2).get('hello', 'world');
+  /// ```
+  ///
+  /// This feature is disabled by default because it introduces a point
+  /// of possible runtime failure - use at your own risk.
+  final bool generateOfKeyFactories;
+
   const AutoLocalized({
     required this.locales,
     this.convertToCamelCase = true,
     this.onBlankValueStrategy = OnBlankValueStrategy.error,
     this.generateGetterMethods = false,
+    this.generateOfKeyFactories = false,
   });
 }

--- a/packages/auto_localized/lib/src/annotation/auto_localized.dart
+++ b/packages/auto_localized/lib/src/annotation/auto_localized.dart
@@ -77,8 +77,8 @@ class AutoLocalized {
   /// ```dart
   /// Strings.ofKey('test_message').getRaw();
   ///
-  /// // or with cast
-  /// (Strings.ofKey('test_message') as ArgLocalizedString2).get('hello', 'world');
+  /// // or with generics
+  /// Strings.ofKey<ArgLocalizedString2>('test_message').get('hello', 'world');
   /// ```
   ///
   /// This feature is disabled by default because it introduces a point

--- a/packages/auto_localized/lib/src/exception/localized_not_found.dart
+++ b/packages/auto_localized/lib/src/exception/localized_not_found.dart
@@ -1,0 +1,10 @@
+class LocalizedStringNotFoundException implements Exception {
+  final String missingKey;
+
+  const LocalizedStringNotFoundException(this.missingKey);
+
+  @override
+  String toString() => 'Error occurred while while trying to find '
+      'LocalizedString of original key: $missingKey. Remember to use original '
+      'key from translation file instead of property name';
+}

--- a/packages/auto_localized_generator/lib/src/config/annotation_config_resolver.dart
+++ b/packages/auto_localized_generator/lib/src/config/annotation_config_resolver.dart
@@ -23,6 +23,7 @@ class AnnotationConfigResolver {
     final convertToCamelCase = _resolveConvertToCamelCase();
     final onBlankValueStrategy = _resolveOnBlankValueStrategy();
     final generateGetterMethods = _resolveGenerateGetterMethods();
+    final generateOfKeyFactories = _resolveGenerateOfKeyFactories();
     final locales = await _resolveLocales();
 
     final config = AnnotationConfig(
@@ -30,6 +31,7 @@ class AnnotationConfigResolver {
       convertToCamelCase,
       onBlankValueStrategy,
       generateGetterMethods,
+      generateOfKeyFactories,
       locales,
     );
 
@@ -96,6 +98,19 @@ class AnnotationConfigResolver {
           'Inspected value equals null.',
     );
     return generateGetters!;
+  }
+
+  bool _resolveGenerateOfKeyFactories() {
+    final generateOfKeyFactories = _annotation
+        .peek(AnnotationConfig.generateOfKeyFactoriesField)
+        ?.boolValue;
+    _throwSourceErrorIf(
+      condition: () => generateOfKeyFactories == null,
+      message: 'Unexpected error occurred while inspecting '
+          '"${AnnotationConfig.generateOfKeyFactoriesField}" in ${_element.name}. '
+          'Inspected value equals null.',
+    );
+    return generateOfKeyFactories!;
   }
 
   Future<List<AnnotationConfigLocale>> _resolveLocales() async {

--- a/packages/auto_localized_generator/lib/src/config/model/annotation_config.dart
+++ b/packages/auto_localized_generator/lib/src/config/model/annotation_config.dart
@@ -8,6 +8,7 @@ class AnnotationConfig {
   static const convertToCamelCaseField = 'convertToCamelCase';
   static const onBlankValueStrategyField = 'onBlankValueStrategy';
   static const generateGetterMethodsField = 'generateGetterMethods';
+  static const generateOfKeyFactoriesField = 'generateOfKeyFactories';
 
   static const onBlankValueStrategyStringMap = {
     'OnBlankValueStrategy.ignore': OnBlankValueStrategy.ignore,
@@ -19,6 +20,7 @@ class AnnotationConfig {
   final bool convertStringsToCamelCase;
   final OnBlankValueStrategy onBlankValueStrategy;
   final bool generateGetterMethods;
+  final bool generateOfKeyFactories;
   final List<AnnotationConfigLocale> locales;
 
   const AnnotationConfig(
@@ -26,6 +28,7 @@ class AnnotationConfig {
     this.convertStringsToCamelCase,
     this.onBlankValueStrategy,
     this.generateGetterMethods,
+    this.generateOfKeyFactories,
     this.locales,
   );
 
@@ -38,6 +41,7 @@ class AnnotationConfig {
           convertStringsToCamelCase == other.convertStringsToCamelCase &&
           onBlankValueStrategy == other.onBlankValueStrategy &&
           generateGetterMethods == other.generateGetterMethods &&
+          generateOfKeyFactories == other.generateOfKeyFactories &&
           locales == other.locales;
 
   @override
@@ -46,6 +50,7 @@ class AnnotationConfig {
       convertStringsToCamelCase.hashCode ^
       onBlankValueStrategy.hashCode ^
       generateGetterMethods.hashCode ^
+      generateOfKeyFactories.hashCode ^
       locales.hashCode;
 
   @override
@@ -54,5 +59,6 @@ class AnnotationConfig {
       'convertStringsToCamelCase: $convertStringsToCamelCase, '
       'onBlankValueStrategy: $onBlankValueStrategy, '
       'generateGetterMethods: $generateGetterMethods, '
+      'generateOfKeyFactories: $generateOfKeyFactories, '
       'locales: $locales}';
 }

--- a/packages/auto_localized_generator/lib/src/exception/forbidden_translation_key_exception.dart
+++ b/packages/auto_localized_generator/lib/src/exception/forbidden_translation_key_exception.dart
@@ -1,0 +1,14 @@
+class ForbiddenTranslationKeyException implements Exception {
+  final String forbiddenKey;
+  final String reservedForFeature;
+
+  const ForbiddenTranslationKeyException(
+    this.forbiddenKey,
+    this.reservedForFeature,
+  );
+
+  @override
+  String toString() => 'An key: "$forbiddenKey" is forbidden to use '
+      'because this is reserved for internal library use, try different name '
+      "or disable '$reservedForFeature' feature in config annotation";
+}

--- a/packages/auto_localized_generator/lib/src/generator/templates/localized_strings_generator.dart
+++ b/packages/auto_localized_generator/lib/src/generator/templates/localized_strings_generator.dart
@@ -92,12 +92,14 @@ class LocalizedStringsGenerator implements CodeGenerator {
   String _generateOfKeyFactories() {
     final buffer = StringBuffer();
     buffer.writeln(
-        '/// Returns an abstract version of [LocalizedString] based on given key');
-    buffer.writeln('/// or null if not exists.');
-    buffer.writeln('static LocalizedString? maybeOfKey(String key) {');
+        '/// Returns an generic version of [LocalizedString] based on given key');
+    buffer.writeln(
+        '/// and type, or null if not exists or given type is not matching.');
+    buffer.writeln(
+        'static T? maybeOfKey<T extends LocalizedString>(String key) {');
     buffer.writeln('try {');
     buffer.writeln(
-        'return allLocalizedStrings.firstWhere((string) => string.key == key);');
+        'return allLocalizedStrings.firstWhere((string) => string.key == key) as T;');
     buffer.writeln('} catch (_) {');
     buffer.writeln('return null;');
     buffer.writeln('}');
@@ -106,9 +108,10 @@ class LocalizedStringsGenerator implements CodeGenerator {
 
     buffer.writeln(
         '/// Returns an abstract version of [LocalizedString] based on given key');
-    buffer.writeln('/// or throws an [Exception] if not exist');
-    buffer.writeln('static LocalizedString ofKey(String key) {');
-    buffer.writeln('final localized = maybeOfKey(key);');
+    buffer.writeln('/// and type, or throws an [Exception] if not exist');
+    buffer.writeln('/// or given type is not matching.');
+    buffer.writeln('static T ofKey<T extends LocalizedString>(String key) {');
+    buffer.writeln('final localized = maybeOfKey<T>(key);');
     buffer.writeln('if (localized != null) return localized;');
     buffer.writeln('throw LocalizedStringNotFoundException(key);');
     buffer.writeln('}');


### PR DESCRIPTION
Solves #8 

Adds opt-in feature `generateOfKeyFactories` that allows you to obtain LocalizedString during runtime by generated methods `ofKey` and `maybeOfKey` 

For example: 
```dart
Strings.ofKey('test_message').getRaw();

// or with cast
(Strings.ofKey('test_message') as ArgLocalizedString2).get('hello', 'world');
```